### PR TITLE
Fixed crash caused by java.security.ProviderException: "Key validity …

### DIFF
--- a/app/src/stages/completed/java/co/temy/securitysample/authentication/EncryptionServices.kt
+++ b/app/src/stages/completed/java/co/temy/securitysample/authentication/EncryptionServices.kt
@@ -111,7 +111,10 @@ class EncryptionServices(context: Context) {
      */
     fun createFingerprintKey() {
         if (SystemServices.hasMarshmallow()) {
-            keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY, true, true)
+            keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY,
+                    userAuthenticationRequired = true,
+                    invalidatedByBiometricEnrollment = true,
+                    userAuthenticationValidWhileOnBody = false)
         }
     }
 

--- a/app/src/stages/stage2/java/co/temy/securitysample/authentication/EncryptionServices.kt
+++ b/app/src/stages/stage2/java/co/temy/securitysample/authentication/EncryptionServices.kt
@@ -90,9 +90,13 @@ class EncryptionServices(context: Context) {
 
     fun createFingerprintKey() {
         if (SystemServices.hasMarshmallow()) {
-            keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY, true, true)
+            keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY,
+                    userAuthenticationRequired = true,
+                    invalidatedByBiometricEnrollment = true,
+                    userAuthenticationValidWhileOnBody = false)
         }
     }
+
 
     fun removeFingerprintKey() {
         if (SystemServices.hasMarshmallow()) {

--- a/app/src/stages/stage3/java/co/temy/securitysample/authentication/EncryptionServices.kt
+++ b/app/src/stages/stage3/java/co/temy/securitysample/authentication/EncryptionServices.kt
@@ -93,9 +93,13 @@ class EncryptionServices(context: Context) {
 
     fun createFingerprintKey() {
         if (SystemServices.hasMarshmallow()) {
-            keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY, true, true)
+            keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY,
+                    userAuthenticationRequired = true,
+                    invalidatedByBiometricEnrollment = true,
+                    userAuthenticationValidWhileOnBody = false)
         }
     }
+
 
     fun removeFingerprintKey() {
         if (SystemServices.hasMarshmallow()) {

--- a/pages/workshop.md
+++ b/pages/workshop.md
@@ -752,7 +752,10 @@ Update `createFingerprintKey` and `removeFingerprintKey` functions:
 ```kotlin
 fun createFingerprintKey() {
     if (SystemServices.hasMarshmallow()) {
-        keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY, true, true)
+        keyStoreWrapper.createAndroidKeyStoreSymmetricKey(FINGERPRINT_KEY,
+                        userAuthenticationRequired = true,
+                        invalidatedByBiometricEnrollment = true,
+                        userAuthenticationValidWhileOnBody = false)
     }
 }
 


### PR DESCRIPTION
…extension while device is on-body is not supported for keys requiring fingerprint authentication" on Nougat

Changed value for userAuthenticationValidWhileOnBody to false when creating fingerprint key, and added named parameters for the method, because it has three boolean parameters and is hard to follow.